### PR TITLE
kernel: embed IKCONFIG from the active build config

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -117,9 +117,9 @@ $(obj)/configs.o: $(obj)/config_data.h
 
 targets += config_data.gz
 
-STOCK_DEFCONFIG := arch/arm64/configs/ginkgo-stock_defconfig
+IKCONFIG_SOURCE := $(KCONFIG_CONFIG)
 
-$(obj)/config_data.gz: $(STOCK_DEFCONFIG) FORCE
+$(obj)/config_data.gz: $(IKCONFIG_SOURCE) FORCE
 	$(call if_changed,gzip)
 
       filechk_ikconfiggz = (echo "static const char kernel_config_data[] __used = MAGIC_START"; cat $< | scripts/basic/bin2c; echo "MAGIC_END;")


### PR DESCRIPTION
**Fix IKCONFIG to embed the active build configuration**


This changes IKCONFIG generation to embed the actual build config used for the kernel build instead of a hardcoded stock defconfig.

  Previously, kernel/config_data.gz was always generated from arch/arm64/configs/ginkgo-stock_defconfig. As a result, /proc/config.gz could report a configuration that did not match the running kernel when the
  build used merged fragments such as device-specific configs or KSU-related configs.

  With this change, config_data.gz is generated from $(KCONFIG_CONFIG), so /proc/config.gz reflects the real final configuration of the built kernel.

  This fixes misleading runtime config inspection and makes debugging feature availability much more reliable.